### PR TITLE
fix/#79 라우트 + UI +API 수정

### DIFF
--- a/src/components/PageHeader.tsx
+++ b/src/components/PageHeader.tsx
@@ -3,6 +3,7 @@ interface PageHeaderProps {
   depth2: string;
   actionLabel?: string;
   onAction?: () => void;
+  onBack?: () => void;
   className?: string;
 }
 
@@ -16,6 +17,7 @@ export default function PageHeader({
   depth2,
   actionLabel,
   onAction,
+  onBack,
   className = '',
 }: PageHeaderProps) {
   const depth1Clamped = clampText(depth1, 15);
@@ -26,7 +28,9 @@ export default function PageHeader({
     >
       <div className="min-w-0 flex-1 font-sans text-[16px] leading-normal font-medium text-[#58534E]">
         <div className="truncate">
-          <span>{depth1Clamped}</span>
+          <span onClick={onBack} className="cursor-pointer">
+            {depth1Clamped}
+          </span>
           <span className="mx-[10px]">&gt;</span>
           <span>{depth2}</span>
         </div>

--- a/src/pages/Main/Bookshelf/BookShelfMemoPage.tsx
+++ b/src/pages/Main/Bookshelf/BookShelfMemoPage.tsx
@@ -1,0 +1,120 @@
+import { useRef, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import Header from '../../../components/Header';
+import PageHeader from '../../../components/PageHeader';
+import useMemoStore from '../../../stores/useMemoStore';
+import { useBookTitle } from '../../../hooks/useBookTitle';
+import type { BookshelfTabKey } from '../../../types/bookshelf.type';
+import { isBookshelfTabKey } from '../../../utils/bookshelf.utils';
+
+export default function BookShelfMemoPage() {
+  const navigate = useNavigate();
+  const { tab: tabParam, bookId } = useParams();
+
+  const tab: BookshelfTabKey = isBookshelfTabKey(tabParam ?? '')
+    ? (tabParam as BookshelfTabKey)
+    : 'reading';
+
+  const numericBookId = Number(bookId);
+
+  const bookTitle = useBookTitle(numericBookId);
+
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  const [memoTitle, setMemoTitle] = useState('');
+  const [page, setPage] = useState('');
+  const [memo, setMemo] = useState(''); // context
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const { addMemo, error } = useMemoStore();
+
+  const handleSubmit = async () => {
+    if (!numericBookId || Number.isNaN(numericBookId)) {
+      alert('bookId가 올바르지 않습니다. URL을 확인해 주세요.');
+      return;
+    }
+
+    const trimmedTitle = memoTitle.trim();
+    const trimmedPage = page.trim();
+    const trimmedMemo = memo.trim();
+
+    if (!trimmedTitle || !trimmedPage || !trimmedMemo) {
+      if (!trimmedMemo) textareaRef.current?.focus();
+      return;
+    }
+
+    try {
+      setIsSubmitting(true);
+
+      await addMemo(
+        { memoTitle: trimmedTitle, context: trimmedMemo, page: trimmedPage },
+        numericBookId,
+      );
+
+      setMemoTitle('');
+      setPage('');
+      setMemo('');
+      navigate(`/bookshelf/${tab}/select/${bookId}`);
+    } catch (err) {
+      console.error('메모 추가 실패:', err);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="flex min-h-screen flex-col items-center bg-[#F7F5F1] pb-[30px] text-[#4C4540]">
+      <Header />
+      <div className="flex flex-col items-start justify-center gap-[10px] self-stretch px-[14px] pt-[20px] pb-[10px]">
+        <PageHeader depth1={bookTitle || '책 제목'} depth2="독서 메모" />
+      </div>
+
+      <section className="flex w-full flex-col gap-[10px] self-stretch px-[16px] py-[10px]">
+        <input
+          value={memoTitle}
+          onChange={(e) => setMemoTitle(e.target.value)}
+          placeholder="메모 제목을 입력해주세요."
+          className="flex items-start gap-[10px] self-stretch rounded-[16px] bg-[#FFFFFF] px-[16px] py-[14px] font-sans text-[16px] leading-normal font-[400] text-[#58534E] not-italic outline-none"
+        />
+        <input
+          value={page}
+          onChange={(e) => setPage(e.target.value)}
+          placeholder="페이지를 입력해주세요."
+          className="flex items-start gap-[10px] self-stretch rounded-[16px] bg-[#FFFFFF] px-[16px] py-[14px] font-sans text-[16px] leading-normal font-[400] text-[#58534E] not-italic outline-none"
+        />
+      </section>
+
+      <main className="flex h-[298px] shrink-0 flex-col items-start gap-[10px] self-stretch px-[16px] py-[10px]">
+        <textarea
+          ref={textareaRef}
+          value={memo}
+          onChange={(event) => setMemo(event.target.value)}
+          placeholder="메모를 입력해주세요."
+          autoFocus
+          className="flex flex-1 items-start gap-[10px] self-stretch rounded-[16px] bg-[#FFFFFF] px-[16px] py-[14px] font-sans text-[16px] leading-normal font-[400] text-[#58534E] not-italic outline-none"
+        />
+      </main>
+
+      <section className="flex flex-col items-center justify-center gap-[10px] self-stretch px-[18px] py-[10px]">
+        <div className="flex flex-col items-start gap-[10px] self-stretch border-t-[1px] border-[#58534E] py-[14px]">
+          {error && (
+            <div className="w-full rounded-[10px] bg-white p-[12px] text-[14px] text-red-500">
+              {error}
+            </div>
+          )}
+
+          <div className="flex items-center justify-end gap-[10px] self-stretch">
+            <button
+              className="font-sans text-[18px] leading-normal font-[500] text-[#58534E] not-italic"
+              onClick={handleSubmit}
+              disabled={isSubmitting}
+              type="button"
+            >
+              {isSubmitting ? '저장 중...' : '작성하기'}
+            </button>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/pages/Main/Bookshelf/BookshelfSelectPage.tsx
+++ b/src/pages/Main/Bookshelf/BookshelfSelectPage.tsx
@@ -366,7 +366,9 @@ export default function BookshelfSelectPage() {
             {/* 작성하기 버튼 → 메모 목록 페이지로 이동 */}
             <button
               type="button"
-              onClick={() => navigate(`/books/${bookId}/memos`)}
+              onClick={() =>
+                navigate(`/bookshelf/${tab}/select/${bookId}/memos`)
+              }
               className="flex w-full items-center gap-[10px] self-stretch rounded-[10px] bg-white px-[12px] py-[14px]"
             >
               <span className="flex-1 text-center font-[Freesentation] text-[16px] leading-normal font-[500] text-[#58534E]">

--- a/src/pages/Main/Bookshelf/router.tsx
+++ b/src/pages/Main/Bookshelf/router.tsx
@@ -1,6 +1,7 @@
 import { Routes, Route, Navigate } from 'react-router-dom';
 import BookshelfPage from './BookshelfPage';
 import BookshelfSelectPage from './BookshelfSelectPage';
+import BookShelfMemoPage from './BookShelfMemoPage';
 
 export default function BookshelfRouter() {
   return (
@@ -13,6 +14,12 @@ export default function BookshelfRouter() {
 
       {/* 책 상세 페이지 */}
       <Route path="/:tab/select/:bookId" element={<BookshelfSelectPage />} />
+
+      {/* 도서 메모 페이지 */}
+      <Route
+        path="/:tab/select/:bookId/memos"
+        element={<BookShelfMemoPage />}
+      />
 
       {/* 404 처리 */}
       <Route path="*" element={<Navigate to="/bookshelf" replace />} />

--- a/src/pages/Main/ReadingFlow/CompletePage.tsx
+++ b/src/pages/Main/ReadingFlow/CompletePage.tsx
@@ -393,7 +393,7 @@ export default function CompletePage() {
         <Button variant="secondary" onClick={() => navigate('/recommend')}>
           추천 도서 보기
         </Button>
-        <Button onClick={() => navigate(`/${tab}/select/${bookId}`)}>
+        <Button onClick={() => navigate(`/bookshelf/${tab}/select/${bookId}`)}>
           나가기
         </Button>
       </section>

--- a/src/pages/Main/ReadingFlow/FinRandomQuestionPage.tsx
+++ b/src/pages/Main/ReadingFlow/FinRandomQuestionPage.tsx
@@ -116,7 +116,7 @@ export default function RandomQuestionPage() {
             className="h-[18px] w-[9px]"
             onClick={() => navigate(-1)}
           />
-          <p className="text-center font-sans text-[18px] leading-normal font-medium text-[#58534E]">
+          <p className="mx-auto max-w-[260px] truncate text-center font-sans text-[18px] leading-normal font-medium text-[#58534E]">
             {bookTitle}
           </p>
         </div>

--- a/src/pages/Main/ReadingFlow/NonCompletePage.tsx
+++ b/src/pages/Main/ReadingFlow/NonCompletePage.tsx
@@ -224,7 +224,7 @@ export default function NonCompletePage() {
 
       {/* 하단 */}
       <section className="flex flex-col items-center justify-center gap-[12px] self-stretch px-[20px] pt-[14px] pb-[4px]">
-        <Button onClick={() => navigate(`/${tab}/select/${bookId}`)}>
+        <Button onClick={() => navigate(`/bookshelf/${tab}/select/${bookId}`)}>
           나가기
         </Button>
       </section>

--- a/src/pages/MyPage/MyReadingMemoPage.tsx
+++ b/src/pages/MyPage/MyReadingMemoPage.tsx
@@ -13,6 +13,7 @@ import {
   updateMemo as apiUpdateMemo,
   type MemoUpsertReq,
 } from '../../api/memoApi';
+import { useNavigate } from 'react-router-dom';
 
 type MyMemoItem = {
   memoId: number;
@@ -46,6 +47,7 @@ export default function MyReadingMemoPage() {
   const [error, setError] = useState<string | null>(null);
 
   const { open } = useModalStore();
+  const navigate = useNavigate();
 
   useEffect(() => {
     void loadFirst();
@@ -221,12 +223,13 @@ export default function MyReadingMemoPage() {
             depth2="독서메모"
             actionLabel={isSelectionMode ? '취소' : '선택'}
             onAction={toggleSelectionMode}
+            onBack={() => navigate(-1)}
           />
         </div>
       </div>
 
       <main
-        className={`flex w-full flex-col items-stretch gap-[10px] px-[16px] py-[10px] ${
+        className={`flex w-full flex-col items-stretch gap-[10px] px-[8px] py-[10px] ${
           isSelectionMode ? 'pb-[90px]' : ''
         }`}
       >
@@ -256,13 +259,13 @@ export default function MyReadingMemoPage() {
 
                   {/* 펼쳐진 경우: 해당 책 메모를 "그 아래"에 렌더 */}
                   {expanded && (
-                    <div className="flex w-full flex-col gap-[16px] pb-[16px]">
+                    <div className="flex w-full flex-col gap-[10px] px-[10px] pb-[16px]">
                       {list.length === 0 ? (
                         <div className="rounded-[10px] bg-white p-[16px] text-[#58534E]">
                           이 책에 작성된 메모가 없어요.
                         </div>
                       ) : (
-                        list.map((memo, index) => (
+                        list.map((memo) => (
                           <Fragment key={memo.memoId}>
                             <MemoCard
                               id={memo.memoId}
@@ -275,9 +278,6 @@ export default function MyReadingMemoPage() {
                               onDelete={handleDeleteOne}
                               onUpdate={editMemo}
                             />
-                            {index < list.length - 1 && (
-                              <div className="h-[1px] w-full bg-[#58534E]" />
-                            )}
                           </Fragment>
                         ))
                       )}


### PR DESCRIPTION
## 📌 작업한 내용
(상세 작업 내용란에 기술)

## 🛠️ 상세 작업 내용
- [x] PageHeader 컴포넌트 : '뒤로 가기' 기능 추가
- [x] BookShelfSelectPage : 관련 라우트 수정
- [x] BookShelfMemoPage : 메모 작성 페이지 생성
- [x] NonCompletePage : 라우트 수정
- [x] CompletePage : 라우트 수정
- [x] FinRandomQuestionPage : BookTitle 말줄임표 추가
- [x] MyReadingMemoPage : 라우트 및 UI 수정

## 📸 스크린샷 또는 영상

## ✅ 테스트 방법
- [x] 기능 정상 동작 확인
- [x] 에러 발생 시 예외 처리 확인
- [x] 디자인/기획서와 일치 여부 확인

## ❓ 관련 이슈
#79 

## 🙋‍♂️ 기타
코드 리팩토링 남음